### PR TITLE
Addition of minor build patches

### DIFF
--- a/linux-anvil/scripts/run_commands
+++ b/linux-anvil/scripts/run_commands
@@ -32,7 +32,7 @@ echo "conda =4.6" >> /opt/conda/conda-meta/pinned && \
 export PATH="/opt/conda/bin:${PATH}" && \
     conda install --yes --quiet conda-build conda-verify anaconda-client jinja2 setuptools && \
     conda install --yes git && \
-    conda clean -tipsy
+    conda clean -tipy
 
 # Install docker tools
 export PATH="/opt/conda/bin:${PATH}" && \
@@ -42,7 +42,7 @@ export PATH="/opt/conda/bin:${PATH}" && \
     conda install --yes conda-forge::tini && \
     export CONDA_TINI_INFO=( `conda list tini | grep tini` ) && \
     echo "tini ${CONDA_TINI_INFO[1]}" >> /opt/conda/conda-meta/pinned && \
-    conda clean -tipsy
+    conda clean -tipy
 
 # Lucky group gets permission to write in the conda dir
 groupadd -g 32766 lucky

--- a/linux-anvil/scripts/run_commands
+++ b/linux-anvil/scripts/run_commands
@@ -23,7 +23,7 @@ curl -s -L https://repo.continuum.io/miniconda/$condapkg > miniconda.sh && \
     rm miniconda.sh
 
 echo "conda =4.6" >> /opt/conda/conda-meta/pinned && \
-    export PATH=/opt/conda/bin:$PATH && \
+    export PATH="/opt/conda/bin:${PATH}" && \
     conda config --set show_channel_urls True && \
     conda update --all --yes && \
     conda clean -tipy

--- a/linux-anvil/scripts/run_commands
+++ b/linux-anvil/scripts/run_commands
@@ -30,7 +30,7 @@ echo "conda =4.6" >> /opt/conda/conda-meta/pinned && \
 
 # Install conda build and deployment tools.
 export PATH="/opt/conda/bin:${PATH}" && \
-    conda install --yes --quiet conda-build conda-verify anaconda-client jinja2 setuptools && \
+    conda install --yes --quiet conda-build=3.22.0 conda-verify anaconda-client jinja2 setuptools && \
     conda install --yes git && \
     conda clean -tipy
 

--- a/linux-anvil/xenial/Dockerfile
+++ b/linux-anvil/xenial/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:xenial
+FROM --platform=linux/amd64 ubuntu:xenial
 
 # Set an encoding to make things work smoothly.
 ENV LANG en_US.UTF-8


### PR DESCRIPTION
This PR mainly addresses 3 issues:

1. The `conda clean -s` option has been deprecated (if it existed - at least it's neither an option in [conda version 4.6.0](https://docs.conda.io/projects/conda/en/4.6.0/commands/clean.html) nor the [latest conda version](https://docs.conda.io/projects/conda/en/latest/commands/clean.html)).
2. Pin `conda-build` version at `3.22.0` since newer versions weirdly raise an `ImportError`:
    - Version `3.22.0` does not do `from conda.auxlib.ish import dals` (https://github.com/conda/conda-build/blob/3.22.0/conda_build/cli/main_build.py)
    - Version `3.23.0` onward (e.g., the latest version `3.25.0`) on line 12 does `from conda.auxlib.ish import dals` (https://github.com/conda/conda-build/blob/3.25.0/conda_build/cli/main_build.py) resulting in an `ImportError`.
3. Set the base image to build with `--platform=linux/amd64`. This was necessary for building on Apple Silicon (tested on M2 chip). Without the `--platform` flag, the Docker build fails with a cryptic message downstream that doesn't diagnose the issue (i.e., it was tough to track down - credits to [this page](https://www.appsloveworld.com/docker/100/5/qemu-x86-64-could-not-open-lib64-ld-linux-x86-64-so-2-no-such-file-or-direct) for insight). I think this flag should work on Intel chips, but would need to be verified. Another strategy would be to add a flag to `dalphaball_docker_build.sh` to use a separate `Dockerfile`, which I will add to this PR if preferable.

Additionally, this PR addresses:
4. Conform the `export` format to `export PATH="/opt/conda/bin:${PATH}"`, which does not change any functionality.