### PR TITLE
cleaning up build process and fixing a symbol mapping bug

### DIFF
--- a/recipes/meta.yaml
+++ b/recipes/meta.yaml
@@ -12,7 +12,7 @@ build:
 requirements:
   build:
     - {{ compiler('c') }}
-    - {{ compiler('fortran') }}<9.0
+    - {{ compiler('fortran') }}
   host:
     - gmp
 

--- a/src/Makefile
+++ b/src/Makefile
@@ -3,15 +3,14 @@ DIR=.
 
 CPU=gcc
 NAMEFUL1=$(DIR)/$(NAME1).$(CPU)
-FFLAGS=-c -O3 -x f77-cpp-input -fsecond-underscore
 LIBRARIES=-lgmp -lm -lgfortran
 LD=$(CC) # use c compiler as frontend for linker
 
 .c.o :
-	$(CC) -c -O3 $(CFLAGS) $(INCS) $<
+	$(CC) -c $(CFLAGS) -O3 -fcommon $(INCS) $<
 
 .f.o :
-	$(FC) $(FFLAGS) $<
+	$(FC) -c $(FFLAGS) -O3 -x f77-cpp-input -fsecond-underscore $<
 
 OBJECTS1 = \
 $(NAME1).o \

--- a/src/binding.c
+++ b/src/binding.c
@@ -51,7 +51,7 @@
 			double *surf, double *vol, double ballwsurf[MAX_ATOM], double ballwvol[MAX_ATOM], 
 			double dwsurf[3*MAX_ATOM], double dwvol[3*MAX_ATOM] );
 
-	extern void F77Name2(cavballs)( double *x, double *y, double *z, double *r, int *ncav );
+	extern void F77Name1(cavballs)( double *x, double *y, double *z, double *r, int *ncav );
 
 void get_surf_vol( int npoints, double *coords, double *radius, double *surf_out, double *vol_out ) {
 	int i;
@@ -346,7 +346,7 @@ void get_cavballs( int npoints, double *coords, double *radius ) {
 	double *z = malloc((MAX_TETRA)*sizeof(double));
 	double *r = malloc((MAX_TETRA)*sizeof(double));
 	int ncav = 0;
-	cavballs_( x, y, z, r, &ncav );
+	F77Name1(cavballs)( x, y, z, r, &ncav );
 	
 	printf("%d\n",ncav);
 	for( i = 0; i<ncav; i++ ) {


### PR DESCRIPTION
This pull request fixes some build issues in a conda environment on a mac. Importantly, to use the most-recent version of the C compilers, the `-fcommon` flag is needed to allow common definitions of global variables as opposed to marking them all `extern` in a header and then declaring them in (exactly) one source file. There are a ton of variables in `gmpvar.h`, so it is preferable to use the previous behavior.

The above fix allows the most-recent fortran compiler to be used, so the version specifier has been removed from `meta.yaml`. 

Finally, the fortran-defined function `cavballs` was declared incorrectly - the fuction declaration appended two underscores, but since the function name in fortran has no trailing underscores, only one should be added. Adjusting the macro from `F77Name2` to `F77Name1` suppresses the implicit function declaration error is now also used when calling the function later on.